### PR TITLE
Update test script to use env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,19 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Automated tests
+
+The repository contains a simple script for verifying that the Firestore
+`translations` collection is populated. Run it with Node after setting the
+required Firebase environment variables:
+
+```bash
+FIREBASE_API_KEY=... FIREBASE_AUTH_DOMAIN=... FIREBASE_PROJECT_ID=... \
+FIREBASE_STORAGE_BUCKET=... FIREBASE_MESSAGING_SENDER_ID=... \
+FIREBASE_APP_ID=... FIREBASE_MEASUREMENT_ID=... \
+node scripts/testTranslations.js
+```
+
+The script exits with a non-zero status if no documents are found or if an error
+occurs so it can be integrated into automated CI pipelines.

--- a/scripts/testTranslations.js
+++ b/scripts/testTranslations.js
@@ -1,15 +1,20 @@
 // Simple test to check if translations collection is populated
 const { initializeApp } = require('firebase/app');
 const { getFirestore, collection, getDocs } = require('firebase/firestore');
+const dotenv = require('dotenv');
 
+// Load environment variables from a `.env` file if present
+dotenv.config();
+
+// Firebase configuration is loaded from environment variables
 const firebaseConfig = {
-  apiKey: "AIzaSyBj4EKhM7aZC3VfOEF3zjmMx8xnUxnEIhM",
-  authDomain: "sermon-notes-assistant.firebaseapp.com", 
-  projectId: "sermon-notes-assistant",
-  storageBucket: "sermon-notes-assistant.firebasestorage.app",
-  messagingSenderId: "111602120623602939751",
-  appId: "1:111602120623602939751:web:84c2b825ad9b7eb86cbbb9",
-  measurementId: "G-CCVS1DTFR6"
+  apiKey: process.env.FIREBASE_API_KEY,
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID,
+  measurementId: process.env.FIREBASE_MEASUREMENT_ID
 };
 
 const app = initializeApp(firebaseConfig);
@@ -30,12 +35,15 @@ async function checkTranslations() {
         const data = doc.data();
         console.log(`- ID: ${doc.id}, Name: ${data.name}, DisplayName: ${data.displayName}`);
       });
+      process.exit(0);
     } else {
       console.log('No translations found in collection');
+      process.exit(1);
     }
     
   } catch (error) {
     console.error('Error:', error);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- load `.env` for `testTranslations.js`
- exit non-zero when the translations collection is empty
- document running the script as an automated test

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842e788042883278c5773b78ead87ff