### PR TITLE
Fix Firebase storage bucket URLs

### DIFF
--- a/scripts/testTranslations.js
+++ b/scripts/testTranslations.js
@@ -6,7 +6,7 @@ const firebaseConfig = {
   apiKey: "AIzaSyBj4EKhM7aZC3VfOEF3zjmMx8xnUxnEIhM",
   authDomain: "sermon-notes-assistant.firebaseapp.com", 
   projectId: "sermon-notes-assistant",
-  storageBucket: "sermon-notes-assistant.firebasestorage.app",
+  storageBucket: "sermon-notes-assistant.appspot.com",
   messagingSenderId: "111602120623602939751",
   appId: "1:111602120623602939751:web:84c2b825ad9b7eb86cbbb9",
   measurementId: "G-CCVS1DTFR6"

--- a/settings-test.html
+++ b/settings-test.html
@@ -56,7 +56,7 @@
             apiKey: "AIzaSyAWH6KZnxrRZfnmCA8116qbj_8uGjGliaU",
             authDomain: "sermon-notes-assistant.firebaseapp.com",
             projectId: "sermon-notes-assistant",
-            storageBucket: "sermon-notes-assistant.firebasestorage.app",
+            storageBucket: "sermon-notes-assistant.appspot.com",
             messagingSenderId: "741896945073",
             appId: "1:741896945073:web:00c666850aead6b4d89190",
             measurementId: "G-59CREPD9PF"

--- a/test-firebase.html
+++ b/test-firebase.html
@@ -15,7 +15,7 @@
             apiKey: "AIzaSyAWH6KZnxrRZfnmCA8116qbj_8uGjGliaU",
             authDomain: "sermon-notes-assistant.firebaseapp.com",
             projectId: "sermon-notes-assistant",
-            storageBucket: "sermon-notes-assistant.firebasestorage.app",
+            storageBucket: "sermon-notes-assistant.appspot.com",
             messagingSenderId: "741896945073",
             appId: "1:741896945073:web:00c666850aead6b4d89190",
             measurementId: "G-59CREPD9PF"


### PR DESCRIPTION
## Summary
- fix Firebase `storageBucket` value in test and script files

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842e771a6788327a1e9d861699d0c48